### PR TITLE
blender 4.0+ support

### DIFF
--- a/vertex_color_master/vcm_ops.py
+++ b/vertex_color_master/vcm_ops.py
@@ -69,8 +69,8 @@ class VERTEXCOLORMASTER_OT_Gradient(bpy.types.Operator):
 
     _handle = None
 
-    line_shader = gpu.shader.from_builtin('2D_SMOOTH_COLOR')
-    circle_shader = gpu.shader.from_builtin('2D_UNIFORM_COLOR')
+    line_shader = gpu.shader.from_builtin('SMOOTH_COLOR' if bpy.app.version >= (4,0) else '2D_SMOOTH_COLOR')
+    circle_shader = gpu.shader.from_builtin('UNIFORM_COLOR' if bpy.app.version >= (4,0) else '2D_UNIFORM_COLOR')
 
     start_color: FloatVectorProperty(
         name="Start Color",


### PR DESCRIPTION
@andyp123 

There is an issue with Blender 4.0+ #42 caused by the [recent breaking change in Python API](https://wiki.blender.org/wiki/Reference/Release_Notes/4.0/Python_API):

![image](https://github.com/andyp123/blender_vertex_color_master/assets/9417531/d329953a-2c71-42b8-8348-4abdaa23adfa)
